### PR TITLE
Broken link to plugin file NethServer/dev#5115

### DIFF
--- a/root/etc/e-smith/templates/etc/openvpn/host-to-net.conf/50security
+++ b/root/etc/e-smith/templates/etc/openvpn/host-to-net.conf/50security
@@ -8,7 +8,7 @@ if ($mode eq 'password') {
     $OUT.="username-as-common-name\n";
 } elsif ($mode eq 'password-certificate') {
     $OUT.= "# Authentication: certificate + password \n";
-    $OUT.="plugin /usr/lib64/openvpn/plugin/lib/openvpn-auth-pam.so /etc/pam.d/login\n";
+    $OUT.="plugin /usr/lib64/openvpn/plugins/openvpn-plugin-auth-pam.so /etc/pam.d/login\n";
 } elsif ($mode eq 'certificate') {
     $OUT.= "# Authentication: certificate\n";
 }


### PR DESCRIPTION
nethserver-openvpn module not working as expected, as openvpn plugin from epel repo has a different filepath:
- old: /usr/lib64/openvpn/plugin/lib/openvpn-auth-pam.so
- correct: /usr/lib64/openvpn/plugins/openvpn-plugin-auth-pam.so

NethServer/dev#5115
