### PR TITLE
Expand CRL expiration

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -32,10 +32,12 @@ my $event = "nethserver-openvpn-update";
 event_actions($event, 
     'initialize-default-databases' => '00',
     'nethserver-vpn-conf' => '20',
+    'nethserver-openvpn-crl' => '30',
     'nethserver-openvpn-net2net' => '40',
 );
 templates2events("/etc/openvpn/host-to-net.conf",  $event);
 templates2events("/etc/openvpn/host-to-net.pool",  $event);
+templates2events("/var/lib/nethserver/certs/ca.cnf",  $event);
 templates2events("/etc/sudoers",  $event);
 event_services($event, 'openvpn@host-to-net' => 'restart');
 
@@ -134,3 +136,14 @@ validator_actions('vpn-create', qw(
 ));
 
 
+#--------------------------------------------------
+# actions for certificate-update event
+#--------------------------------------------------
+
+$event = "certificate-update";
+
+event_actions($event,
+    'nethserver-openvpn-crl' => '30',
+);
+
+templates2events("/var/lib/nethserver/certs/ca.cnf",  $event);

--- a/root/etc/e-smith/events/actions/nethserver-openvpn-crl
+++ b/root/etc/e-smith/events/actions/nethserver-openvpn-crl
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2017 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+#
+# Force CRL expiration after CA certificate
+#
+
+cdir=/var/lib/nethserver/certs
+
+# Read expire date for CA and CRL
+crt_end=$(LANG=C openssl x509 -in /etc/pki/tls/certs/NSRV.crt -noout  -enddate | cut -d'=' -f2)
+crl_end=$(LANG=C openssl crl -in /var/lib/nethserver/certs/crl.pem -noout  -nextupdate | cut -d'=' -f2)
+
+# Convert to UNIX timestamp
+crt_end_s=$(date -d"${crt_end}" +%s)
+crl_end_s=$(date -d"${crl_end}" +%s)
+
+if [ $crl_end_s -lt $crt_end_s ]; then
+    /usr/bin/openssl ca -gencrl -out ${cdir}/crl.pem -config ${cdir}/ca.cnf
+fi

--- a/root/etc/e-smith/templates/var/lib/nethserver/certs/ca.cnf/10base
+++ b/root/etc/e-smith/templates/var/lib/nethserver/certs/ca.cnf/10base
@@ -34,7 +34,7 @@ cert_opt 	= ca_default		# Certificate field options
 
 #crl_extensions	= crl_ext
 default_days	= 365
-default_crl_days= 30
+default_crl_days= {{ $pki{'CertificateDuration'} || 3650 }}
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 policy		= policy_anything


### PR DESCRIPTION
- CRL has same expiration of CA certificate
- ca.conf is now a template
- Force CRL renewal if CRL expires before CA certificate

NethServer/dev#5271