### PR TITLE
openvpn-tunnel-client: skip bogus config

### DIFF
--- a/root/etc/e-smith/templates/openvpn-tunnel-client/20remote
+++ b/root/etc/e-smith/templates/openvpn-tunnel-client/20remote
@@ -9,10 +9,10 @@
     if ($wans) {
         foreach my $remote (split(',',$client->prop('RemoteHost'))) {
             foreach my $wan (split(',',$wans)) {
-                $OUT .= "<connection>\n";
-                $OUT .= "remote $remote\n";
                 $interface = $ndb->get($wan) || next;
                 $ipaddr = $interface->prop('ipaddr') || next;
+                $OUT .= "<connection>\n";
+                $OUT .= "remote $remote\n";
                 $OUT .= "local $ipaddr\n";
                 $OUT .= "</connection>\n";
             }


### PR DESCRIPTION
Step to reproduce the error:

- configure a machine with only one DHCP red interface
- create an OpenVPN client
- enable "Special WAN providers priority order" option
- generated configuration doesn't have the closing `connection` tag:
```
...
<connection>
remote x.xx.zz.xx
...

```

NethServer/dev#5362