### PR TITLE
openvpn-tunnel-server: disable explicit-exit-notify

### DIFF
--- a/root/etc/e-smith/templates/openvpn-tunnel-server/60options
+++ b/root/etc/e-smith/templates/openvpn-tunnel-server/60options
@@ -12,9 +12,6 @@
     if ($compression ne 'disabled') {
         $OUT .= "comp-lzo\n";
     }
-    if ($protocol eq 'udp') {
-        $OUT .= "explicit-exit-notify 1\n";
-    }
     if ($topology eq 'subnet') {
         $OUT .= "client-config-dir ccd\n";
     }


### PR DESCRIPTION
Without this option, in case of configuration changes, the vpn tunnel client will try to
reconnect to the server.