### PR TITLE
tunnels: remove useless duplicate-cn option

### DIFF
--- a/root/etc/e-smith/templates/openvpn-tunnel-server/30certificate
+++ b/root/etc/e-smith/templates/openvpn-tunnel-server/30certificate
@@ -9,7 +9,6 @@
         $OUT .= "ca /var/lib/nethserver/openvpn-tunnels/keys/ca.crt\n";
         $OUT .= "cert /var/lib/nethserver/openvpn-tunnels/keys/ca.crt\n";
         $OUT .= "key /var/lib/nethserver/openvpn-tunnels/keys/ca.key\n";
-        $OUT .= "duplicate-cn\n";
     }
 }
 


### PR DESCRIPTION
A server can be connected only to one client, also avoid warning:

 WARNING: using --duplicate-cn and --client-config-dir together is probably not what you want

NethServer/dev#5469