### PR TITLE
Always enable passtos

### DIFF
--- a/root/etc/e-smith/templates/etc/openvpn/host-to-net.conf/80options
+++ b/root/etc/e-smith/templates/etc/openvpn/host-to-net.conf/80options
@@ -6,6 +6,7 @@
         $OUT .= "compress lzo";
     }
 }
+passtos
 keepalive 20 120
 client-config-dir ccd
 persist-key

--- a/root/etc/e-smith/templates/openvpn-tunnel-client/60options
+++ b/root/etc/e-smith/templates/openvpn-tunnel-client/60options
@@ -17,5 +17,6 @@
         $OUT .= "compress lzo\n";
     }
 }
+passtos
 verb 3
 keepalive 10 60

--- a/root/etc/e-smith/templates/openvpn-tunnel-server/60options
+++ b/root/etc/e-smith/templates/openvpn-tunnel-server/60options
@@ -27,6 +27,7 @@
     }
 
 }
+passtos
 keepalive 10 60
 ping-timer-rem
 persist-key

--- a/root/usr/libexec/nethserver/openvpn-local-client
+++ b/root/usr/libexec/nethserver/openvpn-local-client
@@ -81,5 +81,6 @@ $OUT .= "verb 3\n";
 $OUT .= "persist-key\n";
 $OUT .= "persist-tun\n";
 $OUT .= "nobind\n";
+$OUT .= "passtos\n";
 
 print "$OUT\n";


### PR DESCRIPTION
The `passtos` option will be enabled by default since it shouldn't introduce any problem on existing tunnels and road warrior clients.

NethServer/dev#5760