### PR TITLE
host-to-net: add CustomRoutes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,6 +147,7 @@ Properties:
 * ``PushExtraRoutes``: if ``disabled``, only routes for green interface are pushed, if enabled also all static routes will be pushed. Default is ``enabled``
 * ``PushNbdd``: if set, push the specified NBDD as DHCP option
 * ``PushWins``: if set, push the specified WINS as DHCP option
+* ``CustomRoutes``: a comma separated listed of CIDR to be pushed as extra routes to VPN clients
 
 
 If mode is ``bridged``:

--- a/root/etc/e-smith/templates/etc/openvpn/host-to-net.conf/40route
+++ b/root/etc/e-smith/templates/etc/openvpn/host-to-net.conf/40route
@@ -66,6 +66,16 @@
             }
         }
     }
+
+    my $custom_routes = $openvpn{'CustomRoutes'} || '';
+    if ($custom_routes) {
+        foreach (split(",",$custom_routes)) {
+            my $block = NetAddr::IP->new( $_ ) || "";
+            if ($block) {
+                $OUT .= "push \"route ".$block->addr()." ".$block->mask()."\"\n";
+            }
+        }
+    }
     
     if ($mode ne 'bridged') {
         foreach ($ndb->get_all_by_prop('role' => 'green')) {


### PR DESCRIPTION
Allow to push extra routes without adding fake routes inside the global
network configuration.

NethServer/dev#5760