### PR TITLE
Fix bad permissions on cert private keys

### DIFF
--- a/nethserver-openvpn.spec
+++ b/nethserver-openvpn.spec
@@ -45,6 +45,7 @@ echo "%doc COPYING" >> %{name}-%{version}-filelist
 %files -f %{name}-%{version}-filelist
 %defattr(-,root,root)
 %dir %{_nseventsdir}/%{name}-update
+%dir %attr(0750,root,adm) /var/lib/nethserver/certs
 
 %changelog
 * Wed Sep 18 2019 Giacomo Sanchietti <giacomo.sanchietti@nethesis.it> - 1.9.0-1


### PR DESCRIPTION
The directory `/var/lib/nethserver/certs` is currently not owned by any RPM. It is created as parent dir of `certs/clients`. 

- As Nethgui `srvmgr` (member of `adm`) needs read-only access I change owning group to `adm`.
- As Cockpit API and e-smith actions run as root, no permissions issues should occur.

The patch fixes the permissions on both existing systems and newer ones. However leaked certificates should be revoked.

NethServer/dev#6000