### PR TITLE
Enable OTP in roadwarrior openvpn configuration with google authenticator

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -173,3 +173,10 @@ $event = 'otp-save';
 event_actions($event,
     'nethserver-openvpn-otp' => '10',
 );
+
+# restore otp with post-restore-databases
+
+$event = 'post-restore-data';
+event_actions($event,
+    'nethserver-openvpn-otp' => '10',
+);

--- a/createlinks
+++ b/createlinks
@@ -163,3 +163,11 @@ event_actions('openvpn-tunnel-upload',
     'nethserver-openvpn-upload-client' => '30',
     'firewall-adjust' => '80',
 );
+
+#
+# event otp-save
+#
+$event = 'otp-save';
+event_actions($event,
+    'nethserver-openvpn-otp' => '10',
+);

--- a/createlinks
+++ b/createlinks
@@ -37,6 +37,7 @@ event_actions($event,
     'nethserver-openvpn-net2net' => '40',
     'nethserver-openvpn-create-connections-db' => '50',
 );
+templates2events("/etc/pam.d/openvpn-otp",  $event);
 templates2events("/etc/openvpn/host-to-net.conf",  $event);
 templates2events("/etc/openvpn/host-to-net.pool",  $event);
 templates2events("/var/lib/nethserver/certs/ca.cnf",  $event);
@@ -53,6 +54,7 @@ event_actions($event,
     'firewall-adjust' => '80',
     'trusted-networks-modify' => '95'
 );
+templates2events("/etc/pam.d/openvpn-otp",  $event);
 templates2events("/etc/openvpn/host-to-net.conf",  $event);
 templates2events("/etc/openvpn/host-to-net.pool",  $event);
 event_services($event, 'openvpn@host-to-net' => 'restart');

--- a/nethserver-openvpn.spec
+++ b/nethserver-openvpn.spec
@@ -10,7 +10,7 @@ BuildArch: noarch
 Requires: openvpn, bridge-utils
 Requires: nethserver-firewall-base
 Requires: nethserver-vpn-ui
-
+Requires: google-authenticator perl-Convert-Base32
 BuildRequires: perl
 BuildRequires: nethserver-devtools 
 
@@ -215,5 +215,3 @@ echo "%doc COPYING" >> %{name}-%{version}-filelist
 - VPN: add support for OpenVPN net2net - Feature #1958 [NethServer]
 - VPN: support for OpenVPN roadwarrior - Feature #1956 [NethServer]
 - VPN - Feature #1763 [NethServer]
-
-

--- a/root/etc/e-smith/db/configuration/defaults/openvpn@host-to-net/OtpStatus
+++ b/root/etc/e-smith/db/configuration/defaults/openvpn@host-to-net/OtpStatus
@@ -1,0 +1,1 @@
+disabled

--- a/root/etc/e-smith/events/actions/nethserver-openvpn-otp
+++ b/root/etc/e-smith/events/actions/nethserver-openvpn-otp
@@ -1,0 +1,39 @@
+#!/usr/bin/perl
+
+use warnings;
+use strict;
+use Convert::Base32;
+use NethServer::Password;
+use esmith::ConfigDB;
+
+my $db = esmith::ConfigDB->open_ro() || die("Can't open config db");
+my $OtpStatus = $db->get_prop('openvpn@host-to-net','OtpStatus') || 'disabled';
+
+exit 0 if ($OtpStatus ne 'enabled');
+
+my ($key,$login,$pass,$uid,$gid);
+my $mode = 0400;
+
+foreach my $name (glob('/var/lib/nethserver/home/*')) {
+
+    $name =~ s|/var/lib/nethserver/home/||g;
+    if ( -e "/var/lib/nethserver/home/$name/.2fa_openvpn.secret") {
+      $key = NethServer::Password->new('.2fa.secret',{'defaultDir' => "/var/lib/nethserver/home/$name/"})->getAscii();
+
+      ## clean up
+      $key  =~ s/\R//g;
+
+      # we need to convert the hex token to binary base32 
+      my $secret = uc encode_base32( pack("H*", $key) );
+      open(my $fh, '>', "/var/lib/nethserver/home/$name/.google_authenticator");
+      print $fh "$secret\n\" TOTP_AUTH";
+      close $fh;
+
+      # set permission & ownership
+      ($login,$pass,$uid,$gid) = getpwnam($name);
+      chown $uid,$gid, "/var/lib/nethserver/home/$name/.google_authenticator";
+      chmod $mode,"/var/lib/nethserver/home/$name/.google_authenticator";
+    } else {
+      unlink "/var/lib/nethserver/home/$name/.google_authenticator";
+    }
+}

--- a/root/etc/e-smith/templates/etc/openvpn/host-to-net.conf/50security
+++ b/root/etc/e-smith/templates/etc/openvpn/host-to-net.conf/50security
@@ -4,7 +4,17 @@
 my $_libdir = ( -e '/usr/lib64/' ) ? "/usr/lib64" : "/usr/lib";
 
 my $mode = $openvpn{'AuthMode'} || 'password';
-if ($mode eq 'password') {
+if (($openvpn{'OtpStatus'} eq 'enabled') && ($mode ne 'certificate')) {
+    if ($mode eq 'password') {
+        $OUT.= "# Multi factor authentication: Login + Password + One time password\n";
+        $OUT.= "verify-client-cert none\n" 
+    } else {
+        $OUT.= "# Multi factor authentication: Login + Password + One time password + certificate\n";
+    }
+    $OUT.= "reneg-sec 0\n";
+    $OUT.="plugin ${_libdir}/openvpn/plugins/openvpn-plugin-auth-pam.so /etc/pam.d/openvpn-otp\n";
+}
+elsif ($mode eq 'password') {
     $OUT.= "# Authentication: password\n";
     $OUT.="auth-user-pass-verify /usr/libexec/nethserver/openvpn-pam-auth via-env\n";
     $OUT.="verify-client-cert none\n";

--- a/root/etc/e-smith/templates/etc/pam.d/openvpn-otp/10base
+++ b/root/etc/e-smith/templates/etc/pam.d/openvpn-otp/10base
@@ -1,0 +1,23 @@
+#%PAM-1.0
+auth [user_unknown=ignore success=ok ignore=ignore default=bad] pam_securetty.so
+{
+  # check and set libdir 32/64bit (for armhfp)
+  my $_libdir = ( -e '/usr/lib64/' ) ? "/usr/lib64" : "/usr/lib";
+  $OUT.="auth       required   ${_libdir}/security/pam_google_authenticator.so  forward_pass nullok";
+}
+auth       substack     system-auth
+auth       include      postlogin
+account    required     pam_nologin.so
+account    include      system-auth
+password   include      system-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    required     pam_loginuid.so
+session    optional     pam_console.so
+# pam_selinux.so open should only be followed by sessions to be executed in the user context
+session    required     pam_selinux.so open
+session    required     pam_namespace.so
+session    optional     pam_keyinit.so force revoke
+session    include      system-auth
+session    include      postlogin
+-session   optional     pam_ck_connector.so

--- a/root/usr/libexec/nethserver/openvpn-local-client
+++ b/root/usr/libexec/nethserver/openvpn-local-client
@@ -23,6 +23,8 @@ my $openvpn = $cdb->get('openvpn@host-to-net');
 my $SystemName = $cdb->get('SystemName')->value();
 my $DomainName = $cdb->get('DomainName')->value();
 my $remote = $openvpn->prop('Remote') || "";
+my $otp = $openvpn->prop('OtpStatus') || "disabled";
+my ($name, $passwd, $uid, $gid, $quota, $comment, $gcos, $dir, $shell) = getpwnam($name);
 
 my $mode = $openvpn->prop('Mode') || 'routed';
 if ($mode eq 'routed') {
@@ -53,7 +55,14 @@ $OUT .= "float\n";
 my $mode = $openvpn->prop('AuthMode') || 'password';
 if ($mode eq 'password' or $mode eq 'password-certificate') {
     $OUT.="auth-user-pass\n";
+    if ($otp eq 'enabled') {
+        $OUT .= "reneg-sec 0\n";
+        if ( -e "$dir/.2fa_openvpn.secret") {
+            $OUT .= "auth-nocache\n";
+      }
+    }
 };
+
 if ($mode eq 'certificate' or $mode eq 'password-certificate') {
     $OUT.= "# Authentication: certificate\n";
     $OUT .= "<cert>\n";


### PR DESCRIPTION
install the rpm
enable otp for the user in the setting user page 
enable otp globally in openvpn 

```
config setprop openvpn@host-to-net OtpStatus enabled
signal-event nethserver-openvpn-save
```

create a link to the secret to enable otp & the user

```
ln -s /var/lib/nethserver/home/stephane/.2fa.secret /var/lib/nethserver/home/stephane/.2fa_openvpn.secret
signal-event otp-save
```

download the certificate for the client (should work with old configuration except we still renegotiate the authentication every 3600 seconds, so the communication could be stopped after one hour)

set password+certs or simply password 

when the password prompt fill the password and the otp on the same line

if you password is toto and otp is 123456, then fill : toto123456

Google_authenticatore (GA) still authenticates someone who doesn't have `~/.google_authenticator` file but it simply ignores the missed otp pin 

## Know issues

It works only with real account, but otp is not really designed when we just use certificate, it is to authenticate end user, often certs are for machine. However we could use pam_oath if it is needed

google_authenticator uses HOTP (one time password  or recovery code) of 8 pin, we use 6 pin, so it is not compatible. We could switch to 8 pin globally and pray it is compatible with GA (it should), or state that recovery code won't work, or state that recovery code are different for GA