### PR TITLE
Enable routeback on OVPN zone

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -226,7 +226,8 @@ Common properties:
 * ``Password``: password used for authentication, if ``AuthMode`` is ``password`` or ``password-certificate``
 * ``Protocol``: can be ``udp`` or ``tcp``, default is ``udp``
 * ``RemoteHost``: a list of remote server hostnames or ip addresses
-* ``RemoteNetworks``: list of networks in CIDR format, for each network will be created a route
+* ``RemoteNetworks``: list of networks in CIDR format, for each network will be created a route. This networks will also be used by the firewall library
+  to calculate the zone of VPN hosts used inside the firewall rules.
 * ``RemotePort``: remote host port
 * ``User``: username used for authentication, if ``AuthMode`` is ``password`` or ``password-certificate``
 * ``WanPriorities``: an ordered list of red interfaces which will be used to connect to the server, can be

--- a/README.rst
+++ b/README.rst
@@ -15,16 +15,16 @@ Events
 * ``openvpn-tunnel-delete``: fired when a new tunnel is deleted, takes the tunnel name as argument
 * ``openvpn-tunnel-modify``: fired when a new tunnel is modified, takes the tunnel name as argument
 * ``nethserver-vpn-save``: fired when roadwarrior account or server is changed
-* ``openvpn-tunnel-upload``: used to transform a given file to a read-to-use tunnel client
+* ``openvpn-tunnel-upload``: used to transform a given file into a ready-to-use tunnel client
 
 
 Roadwarrior accounts
 ====================
 
-Accounts are used to identify clients connecting to the server itself. There are two types of account:
+Accounts are used to identify clients connecting to the server itself. There are two types of accounts:
 
 * user account: system user with VPN access using user name and password
-* vpn-only account: simple account with only VPN access
+* vpn-only account: simple account with VPN access only
 
 Each account can be used in a roadwarrior connection (host to net). 
 If a net to net tunnel is needed, ``VPNRemoteNetwork`` and ``VPNRemoteNetmask`` 
@@ -77,7 +77,7 @@ Certificates in PEM format can be created using the command: ::
 
 The ``commonName`` parameter is an unique name stored inside the certificate. 
 The command will generate ``key``, ``crt`` and ``csr`` file.
-Each generated certificate is referred with a numeric id and saved inside ``certindex`` database. OpenSSL will also create a certificated called as with the generated id (eg. ``02.pem``). 
+Each generated certificate is referred with a numeric id and saved inside ``certindex`` database. OpenSSL will also create a certificate named using the generated id (eg. ``02.pem``). 
 
 Certificate revocation
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -128,14 +128,14 @@ Example with netcat: ::
   Max bcast/mcast queue length,0
   END
 
-See more on management option: http://openvpn.net/index.php/open-source/documentation/miscellaneous/79-management-interface.html
+See more on management options: http://openvpn.net/index.php/open-source/documentation/miscellaneous/79-management-interface.html
 
 Configuration database
 ^^^^^^^^^^^^^^^^^^^^^^
 
 Properties:
 
-* ``status``: enable or disabled the OpenVPN server, can be ``enabled`` or ``disabled``, default is ``disabled``
+* ``status``: enable or disable the OpenVPN server, can be ``enabled`` or ``disabled``, default is ``disabled``
 * ``AuthMode``: authentication mode, can be ``password``, ``certificate`` or ``password-certificate``
 * ``UDPPort``: server listen port, default is ``1194``
 * ``Mode``: network mode, can be ``routed`` or ``bridged``. Default is ``routed``.
@@ -193,7 +193,7 @@ Example: ::
 Tunnel topology
 ===============
 
-Available topology are ``subnet`` and ``p2p``
+Available topologies are ``subnet`` and ``p2p``
 
 If topology is ``p2p``:
 
@@ -230,9 +230,9 @@ Common properties:
 * ``RemotePort``: remote host port
 * ``User``: username used for authentication, if ``AuthMode`` is ``password`` or ``password-certificate``
 * ``WanPriorities``: an ordered list of red interfaces which will be used to connect to the server, can be
-  used to prefer a faster WAN other than a slower one
+  used to prefer a faster WAN over a slower one
 * ``Topology``: can be ``subnet`` (default) or ``p2p``
-* ``status``: enable or disabled the OpenVPN server, can be ``enabled`` or ``disabled``, default is ``enabled``
+* ``status``: enable or disable the OpenVPN server, can be ``enabled`` or ``disabled``, default is ``enabled``
 
 Files:
 
@@ -276,7 +276,7 @@ Tunnel servers
 ==============
 
 Servers are instance of OpenVPN listening for incoming connections.
-Each server runs on its own port can handle many client.
+Each server runs on its own port and can handle many clients.
 
 When a server is created the following files will be generated:
 
@@ -296,7 +296,7 @@ Properties:
 * ``PublicAddresses``: list of public IPs or host names used by clients to connect to the server
 * ``RemoteNetworks``: list of networks in CIDR format, for each network will be created a local route
 * ``Topology``: can be ``subnet`` (default) or ``p2p``
-* ``status``: enable or disabled the OpenVPN server, can be ``enabled`` or ``disabled``, default is ``disabled``
+* ``status``: enable or disable the OpenVPN server, can be ``enabled`` or ``disabled``, default is ``disabled``
 
 
 Database reference
@@ -356,13 +356,13 @@ Instances can be inspected using ``systemctl`` command: ::
    systemctl status openvpn@server1
 
 
-The roadwarrior can be found here:
+The roadwarrior logs can be found here:
 
 - ``/var/log/openvpn/host-to-net-status.log``
 - ``/var/log/openvpn/openvpn.log``
 
 
-The log if each OpenVPN instance can be seen using ``journalctl`` command.
+The log of each OpenVPN instance can be seen using ``journalctl`` command.
 Example: ::
 
   journalctl -u openvpn@client1

--- a/lib/perl/NethServer/Firewall/OpenVPN.pm
+++ b/lib/perl/NethServer/Firewall/OpenVPN.pm
@@ -79,5 +79,16 @@ sub openvpn_tunnels
         }
     }
 
+    foreach my $type (qw(tunnel openvpn-tunnel-server)) {
+        foreach my $t ($vpn_db->get_all_by_prop('type' => $type)) {
+            my $nets = $t->prop('RemoteNetworks') || next;
+            foreach (split(/,/,$nets)) {
+                if (Net::IPv4Addr::ipv4_in_network($_, $value)) {
+                    return 'ovpn';
+                }
+            }
+        }
+    }
+
     return '';
 }

--- a/root/etc/e-smith/templates/etc/shorewall/interfaces/99openvpn
+++ b/root/etc/e-smith/templates/etc/shorewall/interfaces/99openvpn
@@ -1,2 +1,12 @@
-ovpn    tun+
+#
+# 99openvpn
+#
+{
+    our $policy = $firewall{'VpnPolicy'} || 'strict';
+    if ($policy eq 'permissive') {
+        $OUT .= "ovpn    tun+    routeback\n";
+    } else {
+        $OUT .= "ovpn    tun+\n";
+    }
+}
 ovpn    tap+


### PR DESCRIPTION
Allow network traffic flow between roadwarrior and remote networks connected to OpenVPN tunnels.
The traffic is blocked by default from built-in `sfilter` Shorewall chain.

To enable it:
```
config setprop firewall VpnPolicy permissive
```

This PR also allows the creation of firewall rules involving hosts inside the remote tunnel network.
It works out-of-the box if the firewall is running the tunnel server.
If the firewall is acting as a tunnel client, the `RemoteNetworks` property must be set, otherwise host objects used inside firewall rules will not be correctly located inside the `ovpn` zone. In this case, just add the `RemoteNetworks` property to the tunnel:
```
db vpn setprop tunnelclient RemoteNetworks 192.168.0.0/24,192.168.1.0/24
```

**Usage scenario**

A firewall configured with:
- net2net tunnel with a remote venue
- roadwarrior enabled with a client connected from remote location
- the roadwarrior client want to reach the venue behind the tunnel

Additional steps:
- if the firewall is the tunnel server, add the roadwarrior network inside the "Local networks"
- if the firewall is the tunnel client, add the roadwarrior network inside the "Remote networks" of the tunnel server in the remote venute
- add the remote network to the roadwarrior routes

NethServer/dev#6136
