### PR TITLE
Push RemoteNetworks with the subnet topology 

### DIFF
--- a/root/usr/share/nethesis/NethServer/Module/OpenVpnTunnels/Servers/Download.php
+++ b/root/usr/share/nethesis/NethServer/Module/OpenVpnTunnels/Servers/Download.php
@@ -54,12 +54,12 @@ class Download extends \Nethgui\Controller\Table\RowAbstractAction
                          'Digest' =>  $record['Digest'],
                          'Cipher' =>  $record['Cipher'],
                          'Topology' => $record['Topology'],
+                         'RemoteNetworks' => $record['LocalNetworks']
                   );
         if ($record['Topology'] == 'p2p') {
              $client['Psk'] = file_get_contents("/var/lib/nethserver/openvpn-tunnels/$name.key");
              $client['LocalPeer'] = $record['RemotePeer'];
              $client['RemotePeer'] = $record['LocalPeer'];
-             $client['RemoteNetworks'] = $record['LocalNetworks'];
              $client['AuthMode'] = 'psk';
         } else {
              $client['AuthMode'] = 'certificate';


### PR DESCRIPTION
The PR intends to 

add RemoteNetworks in the download of nethgui
display RemoteNetworks in the client configuration of nethgui
add route xxx.xxx.xxx.xxx    xxx.xxx.xxx.xxx in the client configuration if it exists whatever if you have chosen Topology subnet or P2P

another PR is linked : https://github.com/NethServer/nethserver-vpn-ui/pull/40


https://github.com/NethServer/dev/issues/6345