### PR TITLE
OpenVPN RW: Indicate on which connectivity a client is connected

### DIFF
--- a/root/usr/libexec/nethserver/openvpn-status3
+++ b/root/usr/libexec/nethserver/openvpn-status3
@@ -3,6 +3,8 @@ use strict;
 use Socket;
 use IO::Handle;
 use JSON;
+use esmith::NetworksDB;
+my $ndb = esmith::NetworksDB->open_ro();
 
 
 sub help() {
@@ -40,12 +42,38 @@ while (defined(my $msg = <TSOCK>)) {
             # Header, Common Name Real Address    Virtual Address Virtual IPv6 Address    Bytes Received  Bytes Sent  Connected Since Connected Since (time_t)    Username    Client ID   Peer ID
             my ($header, $cn, $real_address, $virtual_ipv4, $virtual_ipv6, $bytes_received, $bytes_sent, $since, $username, $client_id, $peer_id) = split('\t', $msg);
             next if ($cn eq 'UNDEF');
+
+            # rerieve the parameters to find information in conntrack
+            #udp      17 172 src=xxx.xxx.xxx.xxx dst=xxx.xxx.xxx.xxx sport=57045 dport=1194 packets=169 bytes=32971 
+            #src=xxx.xxx.xxx.xxx dst=xxx.xxx.xxx.xxx sport=1194 dport=57045 packets=68 bytes=14663 [ASSURED] mark=0 delta-time=27 use=1
+            my ($ipConntrack,$portConntrack) = split(':',$real_address);
+            my ($provider,$RedInterface);
+            my $conntrack = `/usr/sbin/conntrack -L -p udp --src $ipConntrack --sport $portConntrack 2>/dev/null`;
+
+            # Compare and Find the good IP used in red NIC
+            my @srcIP = map { $_ =~ /^src=/ ? $_: () } split('\s', $conntrack);
+            foreach (@srcIP) {
+                next if ($_ =~ /$ipConntrack/);
+                $_ =~ s/^src=//;
+                $RedInterface = $_ ;
+            }
+            # Find the label of the red interface
+            foreach ($ndb->red()) {
+                my $key = $_->key;
+                my $ipaddr = $ndb->get_prop($key,'ipaddr');
+                if ($ipaddr eq  $RedInterface) {
+                    $provider = $ndb->get_prop($key,'nslabel');
+                }
+            }
+ 
             $results{$cn} =  { 
                 real_address => $real_address, 
                 virtual_address => $virtual_ipv4, 
                 bytes_received => $bytes_received,
                 bytes_sent => $bytes_sent,
-                since => $since
+                since => $since,
+                provider => $provider,
+                red_interface => $RedInterface
             }
         }
     }

--- a/root/usr/libexec/nethserver/openvpn-status3
+++ b/root/usr/libexec/nethserver/openvpn-status3
@@ -51,20 +51,11 @@ while (defined(my $msg = <TSOCK>)) {
             my ($ipConntrack,$portConntrack) = split(':',$real_address);
             my ($provider,$RedInterface);
             my $protocol = ($db->get_prop('openvpn@host-to-net', 'UDPPort') ne '') ? 'udp' : 'tcp';
+            my $port = $db->get_prop('openvpn@host-to-net', 'Port') || '1194';
 
-            open(FH, "/usr/sbin/conntrack -L -p $protocol --src $ipConntrack --sport $portConntrack|");
-            my @fields;
-            while (<FH>) {
-                @fields = split('\s');
-                foreach (@fields) {
-                    # Compare and Find the good IP used in red NIC
-                    next if ($_ !~ /^src=/);
-                    next if ($_ =~ /$ipConntrack/);
-                    $_ =~ s/^src=//;
-                    $RedInterface = $_ ;
-                }
-            }
-            close(FH);
+            my $out = `/usr/sbin/conntrack -L -p $protocol --src $ipConntrack --sport $portConntrack --dport $port 2>/dev/null`;
+            $out =~ m/\sdst=(\d+\.\d+\.\d+\.\d+)\s/;
+            $RedInterface = $1;
 
             # Find the label of the red interface
             foreach ($ndb->red()) {

--- a/root/usr/libexec/nethserver/openvpn-status3
+++ b/root/usr/libexec/nethserver/openvpn-status3
@@ -4,7 +4,9 @@ use Socket;
 use IO::Handle;
 use JSON;
 use esmith::NetworksDB;
+use esmith::ConfigDB;
 my $ndb = esmith::NetworksDB->open_ro();
+my $db = esmith::ConfigDB->open_ro();
 
 
 sub help() {
@@ -48,21 +50,28 @@ while (defined(my $msg = <TSOCK>)) {
             #src=xxx.xxx.xxx.xxx dst=xxx.xxx.xxx.xxx sport=1194 dport=57045 packets=68 bytes=14663 [ASSURED] mark=0 delta-time=27 use=1
             my ($ipConntrack,$portConntrack) = split(':',$real_address);
             my ($provider,$RedInterface);
-            my $conntrack = `/usr/sbin/conntrack -L -p udp --src $ipConntrack --sport $portConntrack 2>/dev/null`;
+            my $protocol = ($db->get_prop('openvpn@host-to-net', 'UDPPort') ne '') ? 'udp' : 'tcp';
 
-            # Compare and Find the good IP used in red NIC
-            my @srcIP = map { $_ =~ /^src=/ ? $_: () } split('\s', $conntrack);
-            foreach (@srcIP) {
-                next if ($_ =~ /$ipConntrack/);
-                $_ =~ s/^src=//;
-                $RedInterface = $_ ;
+            open(FH, "/usr/sbin/conntrack -L -p $protocol --src $ipConntrack --sport $portConntrack|");
+            my @fields;
+            while (<FH>) {
+                @fields = split('\s');
+                foreach (@fields) {
+                    # Compare and Find the good IP used in red NIC
+                    next if ($_ !~ /^src=/);
+                    next if ($_ =~ /$ipConntrack/);
+                    $_ =~ s/^src=//;
+                    $RedInterface = $_ ;
+                }
             }
+            close(FH);
+
             # Find the label of the red interface
             foreach ($ndb->red()) {
                 my $key = $_->key;
                 my $ipaddr = $ndb->get_prop($key,'ipaddr');
                 if ($ipaddr eq  $RedInterface) {
-                    $provider = $ndb->get_prop($key,'nslabel');
+                    $provider = $ndb->get_prop($key,'nslabel') || $key;
                 }
             }
  

--- a/root/usr/libexec/nethserver/openvpn-status3
+++ b/root/usr/libexec/nethserver/openvpn-status3
@@ -25,6 +25,34 @@ my $socket = $ARGV[0];
 my $topology = $ARGV[1] || 'subnet';
 exit(1) unless (-e $socket);
 
+# Find the label of the red interface
+# Handle also alias and PPPoE
+my %providers;
+foreach ($ndb->get_all()) {
+    my $iname = $_->key;
+    my $role = $_->prop('role') || next;
+    my $type = $_->prop('type') || next;
+    my $ipaddr;
+    if ($role eq 'red' && $type ne 'xdsl-disabled') {
+        my $bootproto = $_->prop('bootproto') || '';
+        if ($bootproto eq 'none') {
+            $ipaddr = $_->prop('ipaddr');
+        } else {
+            my $cidr = `/sbin/ip -o -4 address show $iname primary 2>/dev/null| head -1 | awk '{print \$4}'`;
+            chomp $cidr;
+            $cidr =~ /^(.*)\/(.*)$/;
+            $ipaddr = $1;
+        }
+        $providers{$ipaddr} = $_->prop('nslabel') || $iname;
+    } elsif ($role eq 'alias') {
+        my ($parent,$id) = split(/:/, $iname);
+        my $parent_role = $ndb->get_prop($parent, 'role') || '';
+        if ($parent_role eq 'red') {
+            $providers{$_->prop('ipaddr')} = $ndb->get_prop($parent, 'nslabel') || $iname;
+        }
+    }
+}
+
 socket(TSOCK, PF_UNIX, SOCK_STREAM,0);
 connect(TSOCK, sockaddr_un($socket)) or exit(1);
 my %results;
@@ -57,20 +85,12 @@ while (defined(my $msg = <TSOCK>)) {
             $out =~ m/\sdst=(\d+\.\d+\.\d+\.\d+)\s/;
             $RedInterface = $1;
 
-            # Find the label of the red interface
-            foreach ($ndb->red()) {
-                my $iname = $_->key;
-                my $cidr = `/sbin/ip -o -4 address show $iname primary 2>/dev/null| head -1 | awk '{print \$4}'`;
-                chomp $cidr;
-                $cidr =~ /^(.*)\/(.*)$/;
-                my $ipaddr = $1;
-                if (defined $ipaddr eq  defined $RedInterface) {
-                    $provider = $ndb->get_prop($iname,'nslabel') || $iname;
-                } else {
-                    $provider = 'unknow';
-                }
+            if ( defined $providers{$RedInterface}  ) {
+                $provider = $providers{$RedInterface}; 
+            } else {
+                $provider = 'unknow';
             }
- 
+
             $results{$cn} =  { 
                 real_address => $real_address, 
                 virtual_address => $virtual_ipv4, 

--- a/root/usr/libexec/nethserver/openvpn-status3
+++ b/root/usr/libexec/nethserver/openvpn-status3
@@ -59,10 +59,15 @@ while (defined(my $msg = <TSOCK>)) {
 
             # Find the label of the red interface
             foreach ($ndb->red()) {
-                my $key = $_->key;
-                my $ipaddr = $ndb->get_prop($key,'ipaddr');
-                if ($ipaddr eq  $RedInterface) {
-                    $provider = $ndb->get_prop($key,'nslabel') || $key;
+                my $iname = $_->key;
+                my $cidr = `/sbin/ip -o -4 address show $iname primary 2>/dev/null| head -1 | awk '{print \$4}'`;
+                chomp $cidr;
+                $cidr =~ /^(.*)\/(.*)$/;
+                my $ipaddr = $1;
+                if (defined $ipaddr eq  defined $RedInterface) {
+                    $provider = $ndb->get_prop($iname,'nslabel') || $iname;
+                } else {
+                    $provider = 'unknow';
                 }
             }
  


### PR DESCRIPTION
Find the connectivity used by the R2W client to connect to the server

it display in json

```
[root@prometheus ~]# /usr/libexec/nethserver/openvpn-status3 /var/spool/openvpn/host-to-net  | jq
{
  "stephane@de-labrusse.fr": {
    "red_interface": "xxx.xxx.xxx.xxx",
    "provider": "Fibre",
    "since": "Wed Jun 16 11:50:26 2021",
    "bytes_received": "948302",
    "bytes_sent": "569338",
    "real_address": "xxx.xxx.xxx.xxx:57045",
    "virtual_address": "192.168.96.30"
  }
}
```

https://github.com/NethServer/dev/issues/6531