### PR TITLE
Add mail notification on connect and disconnect

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -149,6 +149,9 @@ Properties:
 * ``PushWins``: if set, push the specified WINS as DHCP option
 * ``CustomRoutes``: a comma separated listed of CIDR to be pushed as extra routes to VPN clients
 * ``Topology``: set roadwarrior server topology, for valid values see ``man openvpn``
+* ``NotifyStatus``: can be ``enabled`` or ``disabled``, default is ``disabled``. If ``enabled``, send a mail notification to ``NotifyAddresses`` upon
+  roadwarrior user connect or disconnect
+* ``NotifyAddresses``: comma-separated list of mail addresses, destinations for ``NotifyStatus`` property
 
 
 If mode is ``bridged``:
@@ -179,6 +182,8 @@ Example: ::
     Mode=routed
     Netmask=255.255.255.0
     Network=192.168.6.0
+    NotifyAddresses=root@localhost
+    NotifyStatus=enabled
     PushDns=
     PushDomain=
     PushExtraRoutes=enabled

--- a/root/etc/e-smith/db/configuration/defaults/openvpn@host-to-net/NotifyStatus
+++ b/root/etc/e-smith/db/configuration/defaults/openvpn@host-to-net/NotifyStatus
@@ -1,0 +1,1 @@
+disabled

--- a/root/usr/libexec/nethserver/connect-scripts/openvpn-connect-notify
+++ b/root/usr/libexec/nethserver/connect-scripts/openvpn-connect-notify
@@ -1,0 +1,63 @@
+#!/usr/bin/perl
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+#
+# Send a mail notification upon user connect
+# The script always exit with 0 to not change OpenVPN flow
+#
+
+use esmith::ConfigDB;
+use Net::Domain qw(domainname);
+use MIME::Lite;
+
+my $name = $ENV{'common_name'};
+my $vpn_ip = $ENV{'ifconfig_pool_remote_ip'};
+my $remote_ip = $ENV{'untrusted_ip'};
+my $time = scalar localtime $ENV{'time_unix'};
+
+my $db = esmith::ConfigDB->open_ro();
+my $status = $db->get_prop('openvpn@host-to-net', 'NotifyStatus') || 'disabled';
+
+# Exit early if notify is disabled
+exit 0 if ($status ne 'enabled');
+
+my $sender = $db->get_prop('root','SenderAddress') || 'no-reply@'.domainname();
+my @destinations = split(/,/, ($db->get_prop('openvpn@host-to-net', 'NotifyAddresses') || ''));
+
+# Exit
+exit 0 if (!@destinations);
+
+my $text = "The user $name established a VPN connection on $time.
+
+Public IP address:  $remote_ip
+Private IP address: $vpn_ip
+";
+
+my $msg = MIME::Lite->new(
+    From    => $sender,
+    To      => \@destinations,
+    Subject => "VPN access: $name",
+    Data => $text
+);
+$msg->send();
+
+exit 0;

--- a/root/usr/libexec/nethserver/connect-scripts/openvpn-connect-notify
+++ b/root/usr/libexec/nethserver/connect-scripts/openvpn-connect-notify
@@ -29,16 +29,16 @@ use esmith::ConfigDB;
 use Net::Domain qw(domainname);
 use MIME::Lite;
 
-my $name = $ENV{'common_name'};
-my $vpn_ip = $ENV{'ifconfig_pool_remote_ip'};
-my $remote_ip = $ENV{'untrusted_ip'};
-my $time = scalar localtime $ENV{'time_unix'};
-
 my $db = esmith::ConfigDB->open_ro();
 my $status = $db->get_prop('openvpn@host-to-net', 'NotifyStatus') || 'disabled';
 
 # Exit early if notify is disabled
 exit 0 if ($status ne 'enabled');
+
+my $name = $ENV{'common_name'};
+my $vpn_ip = $ENV{'ifconfig_pool_remote_ip'};
+my $remote_ip = $ENV{'untrusted_ip'};
+my $time = scalar localtime $ENV{'time_unix'};
 
 my $sender = $db->get_prop('root','SenderAddress') || 'no-reply@'.domainname();
 my @destinations = split(/,/, ($db->get_prop('openvpn@host-to-net', 'NotifyAddresses') || ''));

--- a/root/usr/libexec/nethserver/disconnect-scripts/openvpn-disconnect-notify
+++ b/root/usr/libexec/nethserver/disconnect-scripts/openvpn-disconnect-notify
@@ -1,0 +1,64 @@
+#!/usr/bin/perl
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+#
+# Send a mail notification upon user disconnect
+# The script always exit with 0 to not change OpenVPN flow
+#
+
+use esmith::ConfigDB;
+use Net::Domain qw(domainname);
+use MIME::Lite;
+
+my $name = $ENV{'common_name'};
+my $duration = $ENV{'time_duration'};
+my $rcvd = $ENV{'bytes_received'};
+my $sent = $ENV{'bytes_sent'};
+
+my $db = esmith::ConfigDB->open_ro();
+my $status = $db->get_prop('openvpn@host-to-net', 'NotifyStatus') || 'disabled';
+
+# Exit early if notify is disabled
+exit 0 if ($status ne 'enabled');
+
+my $sender = $db->get_prop('root','SenderAddress') || 'no-reply@'.domainname();
+my @destinations = split(/,/, ($db->get_prop('openvpn@host-to-net', 'NotifyAddresses') || ''));
+
+# Exit
+exit 0 if (!@destinations);
+
+my $text = "The user $name was disconnected from VPN server.
+
+Duration:  $duration seconds
+Sent: 	   $sent bytes
+Received:  $rcvd bytes
+";
+
+my $msg = MIME::Lite->new(
+    From    => $sender,
+    To      => \@destinations,
+    Subject => "VPN user $name disconnected",
+    Data => $text
+);
+$msg->send();
+
+exit 0;

--- a/root/usr/libexec/nethserver/disconnect-scripts/openvpn-disconnect-notify
+++ b/root/usr/libexec/nethserver/disconnect-scripts/openvpn-disconnect-notify
@@ -29,16 +29,16 @@ use esmith::ConfigDB;
 use Net::Domain qw(domainname);
 use MIME::Lite;
 
-my $name = $ENV{'common_name'};
-my $duration = $ENV{'time_duration'};
-my $rcvd = $ENV{'bytes_received'};
-my $sent = $ENV{'bytes_sent'};
-
 my $db = esmith::ConfigDB->open_ro();
 my $status = $db->get_prop('openvpn@host-to-net', 'NotifyStatus') || 'disabled';
 
 # Exit early if notify is disabled
 exit 0 if ($status ne 'enabled');
+
+my $name = $ENV{'common_name'};
+my $duration = $ENV{'time_duration'};
+my $rcvd = $ENV{'bytes_received'};
+my $sent = $ENV{'bytes_sent'};
 
 my $sender = $db->get_prop('root','SenderAddress') || 'no-reply@'.domainname();
 my @destinations = split(/,/, ($db->get_prop('openvpn@host-to-net', 'NotifyAddresses') || ''));


### PR DESCRIPTION
OpenVPN roadwarrior server will send a mail notification upon user connected/disconnect.

To enable the feature:
```
config setprop openvpn@host-to-net NotifyStatus enabled
config setprop openvpn@host-to-net NotifyAddresses user1@nethserver.org,user2@nethserver.org
```

Example of mail on user connect:
```
From: no-reply@nstest.nethserver.loc
To: root@localhost.nethserver.loc
Subject: VPN access: test1
Message-Id: <20220304183149.6FE8810B606C@nstest.nethserver.loc>

The user test1 established a VPN connection on Fri Mar  4 18:31:49 2022.

Public IP address:  192.168.122.1
Private IP address: 10.2.3.2
```

Example of mail on user disconnect:
```
From: no-reply@nstest.nethserver.loc
To: root@localhost.nethserver.loc
Subject: VPN user test1 disconnected
Message-Id: <20220304183206.C5B7D10B606C@nstest.nethserver.loc>

The user test1 was disconnected from VPN server.

Duration:  17 seconds
Sent: 	   2410 bytes
Received:  4099 bytes
```


NethServer/dev#6643

