### PR TITLE
Add nobind to OpenVPN tunnel client options

### DIFF
--- a/root/etc/e-smith/templates/openvpn-tunnel-client/60options
+++ b/root/etc/e-smith/templates/openvpn-tunnel-client/60options
@@ -19,5 +19,6 @@
     $OUT .= "management /var/spool/openvpn/n2n-".$client->key." unix\n";
 }
 passtos
+nobind
 verb 3
 keepalive 10 60


### PR DESCRIPTION
This commit adds `nobind` to the default template for OpenVPN tunnel clients, letting users have multiple tunnels with the same destination port.

The effect is that the remotes for multiple different tunnels can all be all on the same port (i.e. 1194) and it won't interfere with local roadwarrior/server setups and/or other tunnels using the same port.